### PR TITLE
Fixed Broken Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1358,5 +1358,5 @@ lsadump::dcsync /domain:external.forest.local /all
 
 Detailed Articles:
 
-- [Not A Security Boundary: Breaking Forest Trusts](https://www.harmj0y.net/blog/redteaming/not-a-security-boundary-breaking-forest-trusts/)
+- [Not A Security Boundary: Breaking Forest Trusts](https://blog.harmj0y.net/redteaming/not-a-security-boundary-breaking-forest-trusts/)
 - [Hunting in Active Directory: Unconstrained Delegation & Forests Trusts](https://posts.specterops.io/hunting-in-active-directory-unconstrained-delegation-forests-trusts-71f2b33688e1)


### PR DESCRIPTION

Old link for "Not A Security Boundary: Breaking Forest Trusts"

https://www.harmj0y.net/blog/redteaming/not-a-security-boundary-breaking-forest-trusts/

is moved to new link.

https://blog.harmj0y.net/redteaming/not-a-security-boundary-breaking-forest-trusts/